### PR TITLE
Fix 7z misspelling on Linux, fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ python steamodded_injector.py ~/Library/Application\ Support/Steam/steamapps/com
   - Windows: `cd C:\Users\<USER>\AppData\Roaming\Balatro\Mods` or `cd %appdata%\Balatro\Mods`
   - Linux: `cd /home/$USER/.local/share/Steam/steamapps/compatdata/2379780/pfx/drive_c/users/steamuser/AppData/Roaming/Balatro/Mods`
   - macOS: `cd ~/Library/Application Support/Balatro/mods`
-- Place the mod files in the directory.
-- ```
+- Place the mod files in the `mod` directory, like below:
+```
   mods/
   |-- rng_poker_mod.love
   |-- card_deck_mod.love

--- a/steamodded_injector.py
+++ b/steamodded_injector.py
@@ -151,7 +151,7 @@ if os.name == 'posix':
         command = "7z"  # Update this path as necessary for macOS
     else:
         # This is Linux or another POSIX-compliant OS
-        command = "7zz"
+        command = "7z"
 else:
     # This is for Windows
     command = f"{seven_zip_dir.name}/7z.exe"


### PR DESCRIPTION
Fixes the 7z misspelling on Linux as well, and fixes the incorrect markdown formatting made in the original PR.